### PR TITLE
Remove LLVM/Clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,3 +471,4 @@ capnp: $(CAPNP_BINARY)
 
 clean::
 	-rm -Rf $(CAPNP_DIR)
+


### PR DESCRIPTION
We now use a [separate](https://github.com/NielsMommen/vf-llvm-clang-build) package in `VeriFast` that ships LLVM/Clang.